### PR TITLE
Support for embedding in iframe or window.open

### DIFF
--- a/js/importer.js
+++ b/js/importer.js
@@ -23,6 +23,22 @@ function initImporter(globals){
         }
     }
 
+    window.addEventListener('message', function(e) {
+        if (e.data && e.data.op === 'importFold' && e.data.fold) {
+            globals.filename = e.data.fold.file_title || 'message';
+            globals.extension = 'fold';
+            globals.url = null;
+            globals.pattern.setFoldData(e.data.fold);
+        }
+    });
+    // Tell parent/opening window that we're ready for messages now.
+    var readyMessage = {from: 'OrigamiSimulator', status: 'ready'};
+    if (window.parent) {
+        window.opener.postMessage(readyMessage, '*');
+    } else if (window.opener) {
+        window.opener.postMessage(readyMessage, '*');
+    }
+
     $("#fileSelector").change(function(e) {
         var files = e.target.files; // FileList object
         if (files.length < 1) {

--- a/js/main.js
+++ b/js/main.js
@@ -62,5 +62,13 @@ $(function() {
     globals.vive = initViveInterface(globals);
     globals.videoAnimator = initVideoAnimator(globals);
 
-    $(".demo[data-url='Tessellations/huffmanWaterbomb.svg']").click();//load demo model
+    // Load demo model: waterbomb unless model specified in URL via ?model=FILE
+    // where FILE is the data-url attribute of an <a class="demo">.
+    var model = 'Tessellations/huffmanWaterbomb.svg';
+    var match = /[\\?&]model=([^&#]*)/.exec(location.search);
+    if (match) {
+        model = match[1];
+    }
+    model = model.replace(/'/g, ''); // avoid messing up query
+    $(".demo[data-url='"+model+"']").click();
 });


### PR DESCRIPTION
This small tweak enables another app to embed Origami Simulator in an `<iframe>` or in a popup window via `window.open`, while letting the parent app control Origami Simulator by dynamically opening specified `.fold` data.

Here's an example of it in action: http://erikdemaine.org/cp-editor/
Draw a simple crease pattern like a square of boundary edges and interior mountain/valley creases, then click Simulate: you get a second tab with Origami Simulator running on that pattern.  Then you can change the pattern in the first tab, and click Simulate again to update the model being simulated in the second tab.

@amandaghassaei Let me know if you want to review this before merging.