### PR TITLE
Remove UTF-8 BOM, and report <parsererror>

### DIFF
--- a/js/pattern.js
+++ b/js/pattern.js
@@ -353,9 +353,19 @@ function initPattern(globals){
     }
 
     function loadSVG(url){
+        // Some SVG files start with UTF-8 byte order mark (BOM) EF BB BF,
+        // which encodes in Base64 to 77u/ -- remove this, as it breaks the
+        // XML/SVG parser.
+        url = url.replace(/^(data:image\/svg\+xml;base64,)77u\//, '$1');
+
         SVGloader.load(url, function(svg){
 
             var _$svg = $(svg);
+            if (_$svg.find('parsererror').length) {
+                globals.warn("Error parsing SVG: " + svg.innerText);
+                return console.warn(_$svg.find('parsererror')[0]);
+            }
+
             // Add SVG to page dom to reveal rendered styles (including CSS).
             $(svg).appendTo('body');
 


### PR DESCRIPTION
I recently encountered an SVG file that started with the [UTF-8 BOM](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8):

[box.zip](https://github.com/amandaghassaei/OrigamiSimulator/files/5184859/box.zip)

This caused the SVG parser (specifically, I believe the XML subparser) to crash.  Oddly, this resulted in a parsed SVG that was HTML with an error message.  I added code to report this.

Then I added code to remove this BOM automatically so that the parser works on this file.  Conveniently, the three bytes encode to exactly four bytes in [Base64](https://en.wikipedia.org/wiki/Base64), so I could easily remove it from the URL itself.

