### PR TITLE
Ignore <symbol> and <defs> (except <style>) (#12)

### DIFF
--- a/js/pattern.js
+++ b/js/pattern.js
@@ -383,6 +383,8 @@ function initPattern(globals){
             // }
 
             //format all appropriate svg elements
+            _$svg.find("symbol").remove();
+            _$svg.find("defs > :not(style)").remove();
             var $paths = _$svg.find("path");
             var $lines = _$svg.find("line");
             var $rects = _$svg.find("rect");


### PR DESCRIPTION
Fixes issue common in Inkscape files that make `<defs><rect/></defs>`