### PR TITLE
Listen for "paste" event to import SVG string.

### DIFF
--- a/js/importer.js
+++ b/js/importer.js
@@ -53,7 +53,7 @@ function initImporter(globals){
 
                 $("#vertTol").val(globals.vertTol);
                 $("#importSettingsModal").modal("show");
-                $('#doSVGImport').click(function (e) {
+                $('#doSVGImport').unbind("click").click(function (e) {
                     e.preventDefault();
                     $('#doSVGImport').unbind("click");
                     if (!globals.includeCurves) {
@@ -118,7 +118,7 @@ function initImporter(globals){
                     }
                     $("#vertTol").val(globals.vertTol);
                     $("#importSettingsModal").modal("show");
-                    $('#doSVGImport').click(function (e) {
+                    $('#doSVGImport').unbind("click").click(function (e) {
                         e.preventDefault();
                         $('#doSVGImport').unbind("click");
                         globals.filename = name;

--- a/js/importer.js
+++ b/js/importer.js
@@ -34,6 +34,39 @@ function initImporter(globals){
         }
     }
 
+    // Adobe Illustrator and Cuttle.xyz copy vector shapes as SVG string. By
+    // listening for a paste event, we can turn the SVG string into a Blob
+    // to load it as the pattern. After this paste handler, it has the same code
+    // path as selecting a local file.
+    window.addEventListener('paste', function (e) {
+        console.log("paste");
+        // Make a synthetic svg file from text
+        var text = e.clipboardData.getData('text/plain');
+        if (text.includes("<svg")) {
+            var blob = new Blob([text], {type: 'image/svg+xml'});
+
+            globals.url = null;
+            globals.filename = "paste";
+            globals.extension = "svg";
+
+            reader.onload = function () {
+
+                $("#vertTol").val(globals.vertTol);
+                $("#importSettingsModal").modal("show");
+                $('#doSVGImport').click(function (e) {
+                    e.preventDefault();
+                    $('#doSVGImport').unbind("click");
+                    if (!globals.includeCurves) {
+                        globals.pattern.loadSVG(reader.result);    
+                    } else {
+                        globals.curvedFolding.loadSVG(reader.result);
+                    }
+                });
+            }
+            reader.readAsDataURL(blob);
+        }
+    });
+
     window.addEventListener('message', function(e) {
         if (!e.data) return;
         if (e.data.op === 'importFold' && e.data.fold) {


### PR DESCRIPTION
At https://cuttle.xyz we appreciate being able to copy and paste between vector-editing apps with the defacto "copy svg string" pattern.

This PR makes it possible to paste an SVG string, which opens the same import dialog as is used when opening a file from the local system.

This makes it smoother to test design iterations. I can make a revision in Cuttle, copy, and paste in Origami Simulator, without saving a file to the local system in between.

I had fun with this while testing the PR:
![Cuttle.xyz CAD design in one window, with the design simulated in Origami Simulator in the other file](https://user-images.githubusercontent.com/395307/143877959-72451b00-6cd2-4e45-b519-b44818cabdec.png)
