### PR TITLE
miyamotoTower.svg added two missing "join" creases

### DIFF
--- a/assets/Kirigami/miyamotoTower.svg
+++ b/assets/Kirigami/miyamotoTower.svg
@@ -238,4 +238,6 @@
 <line fill="none" stroke="#FFFF00" stroke-width="0.9072" stroke-linecap="round" stroke-linejoin="round" x1="383.399" y1="387.111" x2="399.738" y2="373.375"/>
 <line fill="none" stroke="#FFFF00" stroke-width="0.9072" stroke-linecap="round" stroke-linejoin="round" x1="208.121" y1="389.709" x2="194.387" y2="373.375"/>
 <line fill="none" stroke="#FFFF00" stroke-width="0.9072" stroke-linecap="round" stroke-linejoin="round" x1="210.72" y1="564.992" x2="194.383" y2="578.727"/>
+<line fill="none" stroke="#FFFF00" stroke-width="0.9072" stroke-linecap="round" stroke-linejoin="round" x1="267.629" y1="519.22" x2="260.757" y2="527.388"/>
+<line fill="none" stroke="#FFFF00" stroke-width="0.9072" stroke-linecap="round" stroke-linejoin="round" x1="260.757" y1="512.351" x2="260.757" y2="527.388"/>
 </svg>


### PR DESCRIPTION
near the center, bottom left, there are two missing yellow lines. it works fine without this, this is mostly just for my ocd.